### PR TITLE
Fix filename in package.json to make grow.js includable

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {},
   "license": "BSD-3-Clause",
-  "main": "./index.js",
+  "main": "./grow.js",
   "bugs": {
     "url": "http://github.com/CommonGarden/grow.js/issues"
   },


### PR DESCRIPTION
When trying to import, it would look for the previously mentioned
`index.js` file, which didn't exit. Because `grow.js` contains the
module exports, the most straightforward fix is to just change the
exported file name in `package.json`
